### PR TITLE
fixing validation bug in middleware

### DIFF
--- a/apps/server/src/shared/middlewares/validate.middleware.ts
+++ b/apps/server/src/shared/middlewares/validate.middleware.ts
@@ -30,7 +30,7 @@ export function validate(schemas: ValidationSchemas) {
         return;
       }
 
-      (req as any)[target] = result.data;
+      Object.defineProperty(req, target, { value: result.data, writable: true, configurable: true });
     }
 
     next();


### PR DESCRIPTION
req.query is read-only in newer versions of Express/Node — can't assign directly. 
Fixed using Object.defineProperty